### PR TITLE
Remove @next/font package and import  from

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "dev": "next dev"
   },
   "dependencies": {
-    "@next/font": "latest",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pages/font-next-font.js
+++ b/pages/font-next-font.js
@@ -1,5 +1,5 @@
 import Layout from "../components/layout";
-import { MuseoModerno } from "@next/font/google";
+import { MuseoModerno } from "next/font/google";
 
 const museo = MuseoModerno({
   subsets: ["latin"],


### PR DESCRIPTION
See: https://nextjs.org/docs/messages/built-in-next-font

With the release of NextJS 15, importing from `@next/font` causes the build to fail. This PR implements the fix recommended by NextJS.