### PR TITLE
Update README with Next.js version override info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ To use a different version of Next.js instead of `latest`, specify the version i
 variable `NEXTJS_VERSION_OVERRIDE` in Amplify Hosting. The `patch-next.sh` file take care of 
 installing the desired version during the build (see amplify.yml). For example you can specify 
 `canary` or `13.4.12`.
+
+
+PR test


### PR DESCRIPTION
Add a note about specifying Next.js version in Amplify Hosting.