### PR TITLE
fix(next): pin to >=16.0.0 <20.0.0 to skip prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev"
   },
   "dependencies": {
-    "next": "latest",
+    "next": ">=16.0.0 <20.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "swr": "^2.0.0"


### PR DESCRIPTION
## Summary

Pin `next` in `package.json` from `"latest"` to `">=16.0.0 <20.0.0"` so this benchmark app skips `-preview` / `-canary` / `-rc` prereleases while still tracking stable Next.js majors within a sane window.

## Why

Vercel published `next@16.3.0-preview.0` (2026-06-09 19:41:34Z) with `optionalDependencies` pinned to `@next/swc-linux-x64-gnu@16.3.0-preview.0`, but never published the matching native binary at that version. They also promoted the npm `latest` dist-tag to the broken preview, so every consumer doing `npm install next@latest` (or pinning `"next": "latest"` in `package.json`) resolves to it.

`npm install` itself succeeds because `optionalDependencies` 404s are non-fatal. The failure surfaces during `next build`, when Next.js's runtime fallback fetcher tries to download the same missing tarball:

```
⨯ Failed to download swc package from https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0-preview.0.tgz
unhandledRejection Error: request failed with status 404
!!! Build failed
```

State of the npm registry as of 2026-06-09 22:00Z:

| Item | State |
|---|---|
| `@next/swc-linux-x64-gnu@16.3.0-preview.0` tarball | 404 (never published) |
| `@next/swc-linux-x64-gnu@16.3.0-preview.2` tarball | 200 (exists) |
| `next@16.3.0-preview.2` optionalDep pin | matches the published binary, would build fine |
| `next` dist-tag `latest` | still `16.3.0-preview.0` (broken) |
| `next` dist-tag `preview` | `16.3.0-preview.2` (working) |

Vercel published a fixed `16.3.0-preview.2` plus a `16.2.8` stable rollback after the breakage but did not move `latest` off the poisoned `preview.0`. Consuming the `latest` dist-tag is therefore unsafe right now.

## Fix

`">=16.0.0 <20.0.0"` resolves to the highest stable release within the 16.x-19.x window (today: `16.2.8`), floats forward when 16.3.0+ stable lands, allows future major bumps up to but not including 20.0.0, and excludes prereleases per npm semver rules.

## Test plan

- [ ] `npm install` resolves `next` to `16.2.8` (or whatever the current stable head within the window is).
- [ ] `npm run build` completes without the SWC-tarball 404.